### PR TITLE
docs: Update version of pytorch/cuda shown on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Installation (updated on 02/28/2022)
         
         conda activate YOUR_ENV_NAME
 
-* install the latest pytorch package, following the instructions on [pytorch.org](https://pytorch.org/get-started/locally/)
+* install the latest pytorch package, following the instructions on [pytorch.org](https://pytorch.org/get-started/locally/), for example:
 	
-	conda install -c nvidia cudatoolkit
-	conda install -c pytorch pytorch 
+        conda install pytorch==1.12.1 cudatoolkit=11.6 -c pytorch -c conda-forge
+
 
 * clone and install boost-corr
         


### PR DESCRIPTION
The older version no longer installs a version of pytorch which uses a compatible version of cudatoolkit.